### PR TITLE
change the format for environment variable to be different from endly

### DIFF
--- a/util.go
+++ b/util.go
@@ -17,7 +17,7 @@ import (
 
 const timeVariableExpr = "<dateFormat:"
 const modeVarableExpr = "<mod:"
-const userVariableExpr = "${env.USER}"
+const userVariableExpr = "##env.USER##"
 
 var jsonDecoderFactory = toolbox.NewJSONDecoderFactory()
 var jsonEncoderFactory = toolbox.NewJSONEncoderFactory()


### PR DESCRIPTION
endly replaces ${env.USER} in the etly so changing the format of env Variable in ETLY 